### PR TITLE
Fix propagation of 'device' setting from 'models.load_network' to `la…

### DIFF
--- a/src/layers.py
+++ b/src/layers.py
@@ -54,6 +54,7 @@ class UnTAN(nn.Module):
         union_tp=None,
         dropout=0.0,
         no_mix=True,
+        device = 'cuda'
     ):
         super().__init__()
         assert embed_time % num_heads == 0
@@ -69,7 +70,7 @@ class UnTAN(nn.Module):
             nn.Linear(embed_time, embed_time, bias=False),
             nn.Linear(input_size * num_heads, nhidden, bias=False)
         ])
-        self.time_emb = TimeEmbedding(embed_time, arg='periodic')
+        self.time_emb = TimeEmbedding(embed_time, arg='periodic',device=device)
         self.dropout = nn.Dropout(p=dropout)
         self.union_tp = union_tp
         self.no_mix = no_mix

--- a/src/models.py
+++ b/src/models.py
@@ -26,6 +26,7 @@ def load_network(args, dim, union_tp=None, device="cuda"):
             mse_weight=args.mse_weight,
             norm=args.norm,
             mixing=args.mixing,
+            device=device
         ).to(device)
     elif args.net == 'hetvae_det':
         net = HeTVAE_DET(
@@ -46,6 +47,7 @@ def load_network(args, dim, union_tp=None, device="cuda"):
             mse_weight=args.mse_weight,
             norm=args.norm,
             mixing=args.mixing,
+            device=device
         ).to(device)
     elif args.net == 'hetvae_prob':
         net = HeTVAE_PROB(
@@ -66,6 +68,7 @@ def load_network(args, dim, union_tp=None, device="cuda"):
             mse_weight=args.mse_weight,
             norm=args.norm,
             mixing=args.mixing,
+            device=device
         ).to(device)
     else:
         raise ValueError("Network not available")

--- a/src/vae_models.py
+++ b/src/vae_models.py
@@ -243,12 +243,14 @@ class HeTVAE_DET(TVAE):
             intensity=self.intensity,
             union_tp=self.union_tp,
             no_mix=True,
+            device=self.device
         )
         self.decoder = UnTAN(
             input_dim=self.latent_dim,
             nhidden=self.nhidden,
             embed_time=self.embed_time,
             num_heads=self.num_heads,
+            device=self.device
         )
 
 
@@ -276,6 +278,7 @@ class HeTVAE(HeTVAE_DET):
             nhidden=self.nhidden,
             embed_time=self.embed_time,
             num_heads=self.num_heads,
+            device=self.device
         )
 
     def encode(self, context_x, context_y):


### PR DESCRIPTION
Hey, thanks for your paper and code!

I was trying to run it on my Mac m1, that has cpu only, but setting device with load_network lead to error.
```python
>>>device = 'cpu'
>>>net = models.load_network(args, dim, union_tp,device=device)
>>>qz, hidden = net.encode(context_x, context_y)
AssertionError: Torch not compiled with CUDA enabled
```

This is because `net.to(device)` is just not enough. You see, `layer.TimeEmbedding` explicitly puts data to `self.device`,
and setting `net.to(device)` doesn't change the field of class  `layer.TimeEmbedding.device`
https://github.com/reml-lab/hetvae/blob/78296e28f0daa592b4bfa63076d23fd6d75b1c9f/src/layers.py#L32

The solution is just propagate the field `self.device` straight through the `models.load_network` to `layer.TimeEmbedding` as it is done in the pull request.

Otherwise just get rid of explicit moving to device in `layer.TimeEmbedding`  if it is not needed anymore.
  
